### PR TITLE
Update js2xmlparser.js

### DIFF
--- a/lib/js2xmlparser.js
+++ b/lib/js2xmlparser.js
@@ -154,8 +154,8 @@ var toXML = function(object) {
     // Finalize XML at end of process
     if (level === 0) {
 
-        // Remove extra line break at end of file
-        xml = xml.substring(0, xml.length - 1);
+        // Strip trailing whitespace
+        xml = xml.replace(/\s+$/g, '');
 
         // Add XML declaration
         if (xmlDeclaration)


### PR DESCRIPTION
If prettyPrinting is disabled, the last > is being removed from the XML. Instead of removing the last character, we use a regular expression to remove trailing whitespace.
