### PR TITLE
Crashes when object value is NULL

### DIFF
--- a/lib/js2xmlparser.js
+++ b/lib/js2xmlparser.js
@@ -210,7 +210,7 @@ var toString = function(data) {
 
     // Cast data to string
     if (typeof data !== "string")
-        data = data.toString();
+        data = (data === null) ? "" : data.toString();
 
     // Escape illegal XML characters
     data = data.replace(/&/g, "&amp;")


### PR DESCRIPTION
Fixed it so that if an object's value is NULL it is written as an empty string to the XML.
