### PR TITLE
`wrapArray` option.

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -31,3 +31,9 @@ var data = {
 };
 
 console.log(js2xmlparser("person", data));
+console.log(js2xmlparser("person", data, {
+    wrapArray: {
+        enabled: true,
+        element: "item"
+    }
+}));

--- a/lib/js2xmlparser.js
+++ b/lib/js2xmlparser.js
@@ -4,6 +4,8 @@ var xmlEncoding = "UTF-8";
 var attributeString = "@";
 var valueString = "#";
 var prettyPrinting = true;
+var wrapArray = false;
+var wrapArrayItem = "item";
 var indentString = "\t";
 
 module.exports = function (root, data, options) {
@@ -38,6 +40,18 @@ var init = function(root, data, options) {
                 else
                     throw new Error("declaration.encoding option must be a string or null");
             }
+        }
+        if ("wrapArray" in options) {
+            if ("enabled" in options.wrapArray)
+                if (typeof options.wrapArray.enabled === "boolean")
+                    wrapArray = options.wrapArray.enabled;
+                else
+                    throw new Error("wrapArray.enabled option must be a boolean");
+            if ("element" in options.wrapArray)
+                if (typeof options.wrapArray.element === "string")
+                    wrapArrayItem = options.wrapArray.element;
+                else
+                    throw new Error("wrapArray.element option must be a boolean");
         }
         if ("attributeString" in options) {
 
@@ -97,14 +111,23 @@ var toXML = function(object) {
 
         // Arrays
         if (Object.prototype.toString.call(object[property]) === "[object Array]") {
+            if (wrapArray) {
+                var tmpXML = addBreak(addIndent("<" + property + ">", level));
+                for (var i = 0; i < object[property].length; i++) {
+                    var obj = {};
+                    obj[wrapArrayItem] = object[property][i];
+                    tmpXML = toXML(obj, tmpXML, level + 1);
+                }
+                xml += tmpXML;
+                xml += addBreak(addIndent("</" + property + ">", level));
+            } else {
+                // Create separate object for each array element and pass to this function
+                for (var i = 0; i < object[property].length; i++) {
+                   var obj = {};
+                   obj[property] = object[property][i];
 
-            // Create separate object for each array element and pass to this function
-            for (var i = 0; i < object[property].length; i++) {
-
-                var obj = {};
-                obj[property] = object[property][i];
-
-                xml = toXML(obj, xml, level);
+                   xml = toXML(obj, xml, level);
+                }                
             }
         }
         // JSON-type objects with properties


### PR DESCRIPTION
`wrapArray.enabled` creates one XML array element, and then a new child element for every item in the array. By default, the new element will have the name "item", but that can be overridden with `wrapArray.element`.

The example.js outputs the converted XML with both options.
