### PR TITLE
added support for convert options

### DIFF
--- a/lib/js2xmlparser.js
+++ b/lib/js2xmlparser.js
@@ -5,6 +5,7 @@ var attributeString = "@";
 var valueString = "#";
 var prettyPrinting = true;
 var indentString = "\t";
+var convertOptions = {};
 
 module.exports = function (root, data, options) {
 
@@ -70,6 +71,12 @@ var init = function(root, data, options) {
                 else
                     throw new Error("prettyPrinting.indentString option must be a string");
             }
+        }
+        if ("convertMap" in options) {
+            if (typeof options.convertMap === "object")
+                convertOptions = options.convertMap;
+            else
+                throw new Error("convertMap option must be a map");
         }
     }
 
@@ -208,8 +215,12 @@ var toString = function(data) {
     else if (Object.prototype.toString.call(data) === "[object Object]" && Object.keys(data).length === 0)
         data = "";
 
-    // Cast data to string
-    if (typeof data !== "string")
+    if (typeof data in convertOptions)
+        data = convertOptions[typeof data](data);
+    else if ("*" in convertOptions)
+        data = convertOptions["*"](data);
+    else if (typeof data !== "string")
+        // Cast data to string
         data = (data === null) ? "" : data.toString();
 
     // Escape illegal XML characters


### PR DESCRIPTION
Hi,
I have added an option to allow custom formatting of data, e.g. I need to convert boolean values to 0 and 1 instead of true/false. Also undefined doesn't have toString method, as a result toXml fails with an error exception.
And the last part is '*' case which allows to intercept all calls of toString, would be good to have some sort of a context, like a path to the current element, but for me it works quite fine as is, my only need was boolean and undefined values.
