### PR TITLE
Wrap `valueString`s with CDATA instead of escaping with `toString`.

### DIFF
--- a/lib/js2xmlparser.js
+++ b/lib/js2xmlparser.js
@@ -213,7 +213,7 @@ var toString = function(data, useCDATA) {
         data = (data === null) ? "" : data.toString();
 
     if (useCDATA) {
-        data = '<![CDATA[' + data.replace(']]>', ']]\\>') + ']]>';
+        data = '<![CDATA[' + data.replace(/]]>/gm, ']]\\>') + ']]>';
     } else {
         // Escape illegal XML characters
         data = data.replace(/&/g, "&amp;")


### PR DESCRIPTION
Add second param to `toString` to allow it to return the stringified data wrapped in a CDATA tag instead of always escaping characters. 

This is used on the valueString.
