### PR TITLE
add ability to include child nodes without wrapping them in another node

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -107,3 +107,29 @@ var example5Options = {
 };
 
 console.log(js2xmlparser("person", example5, example5Options));
+console.log();
+
+console.log("EXAMPLE 6");
+console.log("=========");
+
+var example6 = {
+    ">": [{
+        "Car": {
+            "@": {type: "passenger"},
+            "wheels": 4,
+            "doors": 4
+        }
+    }, {
+        "Car": {
+            "@": {type: "transport"},
+            "wheels": 18,
+            "doors": 2
+        }
+    }]
+};
+
+var example6Options = {};
+
+console.log(js2xmlparser("Vehicles", example6, example6Options));
+console.log();
+

--- a/lib/js2xmlparser.js
+++ b/lib/js2xmlparser.js
@@ -13,6 +13,7 @@
     var xmlEncoding = "UTF-8";
     var attributeString = "@";
     var valueString = "#";
+    var childString = ">";
     var prettyPrinting = true;
     var indentString = "\t";
 
@@ -101,6 +102,14 @@
                     throw new Error("valueString option must be a string");
                 }
             }
+            if ("childString" in options) {
+                if (typeof options.childString === "string") {
+                    childString = options.childString;
+                }
+                else {
+                    throw new Error("childString option must be a string");
+                }
+            }
             if ("prettyPrinting" in options) {
                 if ("enabled" in options.prettyPrinting) {
                     if (typeof options.prettyPrinting.enabled === "boolean") {
@@ -157,7 +166,13 @@
         for (var property in object) {
             // Arrays
             if (Object.prototype.toString.call(object[property]) === "[object Array]") {
-                if (wrapArray) {
+                if (property === childString) {
+                    for (i = 0; i < object[property].length; i++) {
+                        tempObject = object[property][i];
+                        xml = toXML(tempObject, xml, level);
+                    }
+                }
+                else if (wrapArray) {
                     // Create separate XML elements for each array element, but wrap all elements in a single element
                     xml += addBreak(addIndent("<" + property + ">", level));
                     for (i = 0; i < object[property].length; i++) {
@@ -325,6 +340,7 @@
         xmlEncoding = "UTF-8";
         attributeString = "@";
         valueString = "#";
+        childString = ">"
         prettyPrinting = true;
         indentString = "\t";
     };


### PR DESCRIPTION
this is overrideable by setting the 'childString' option, which
defaults to '>'. this is incompatible with wrapArray.

fixes issue #9
