### PR TITLE
Add support for wrapArray.elementName being a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The js2xmlparser module contains one function which takes the following argument
     * `wrapArray` - array wrapping options object (optional)
         * `enabled` - if true, all elements in an array will be added to a single XML element as child elements; if
           false, array elements will be placed in their own XML elements (optional, default is false)
-        * `elementName` - name of XML child elements when array wrapping is enabled (optional, default is "item")
+        * `elementName` - string or function to define the name of XML child elements when array wrapping is enabled (optional, default is "item")
+            * when `elementName` is a function, it should return a string. The only parameter passed to the function is the parent name.
     * `useCDATA` - if true, all strings are enclosed in CDATA tags instead of escaping illegal XML characters (optional,
       default is false)
     * `convertMap` - object mapping certain types of objects (as given by `Object.prototype.toString.call(<object>)`) to

--- a/lib/js2xmlparser.js
+++ b/lib/js2xmlparser.js
@@ -61,11 +61,12 @@
                     }
                 }
                 if ("elementName" in options.wrapArray) {
-                    if (typeof options.wrapArray.elementName === "string") {
+                    if (typeof options.wrapArray.elementName === "string" ||
+                            typeof options.wrapArray.elementName === "function") {
                         wrapArrayItem = options.wrapArray.elementName;
                     }
                     else {
-                        throw new Error("wrapArray.elementName option must be a boolean");
+                        throw new Error("wrapArray.elementName option must be a string or function");
                     }
                 }
             }
@@ -160,9 +161,15 @@
                 if (wrapArray) {
                     // Create separate XML elements for each array element, but wrap all elements in a single element
                     xml += addBreak(addIndent("<" + property + ">", level));
+
+                    var elementName = wrapArrayItem;
+                    if (typeof wrapArrayItem === "function") {
+                        elementName = wrapArrayItem(property);
+                    }
+                    
                     for (i = 0; i < object[property].length; i++) {
                         tempObject = {};
-                        tempObject[wrapArrayItem] = object[property][i];
+                        tempObject[elementName] = object[property][i];
                         xml = toXML(tempObject, xml, level + 1);
                     }
                     xml += addBreak(addIndent("</" + property + ">", level));


### PR DESCRIPTION
So the child names can be determined by the name of the parent.

Example:

``` javascript
js2xmlparser("root", data, {
  wrapArray: {
    enabled: true,
    elementName: function (parent) { 
      return singularize(parent);
    }
  }
});
```
