### PR TITLE
Fix issue with useCDATA option to not add CDATA elements to XML attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The js2xmlparser module contains one function which takes the following argument
         * `encoding` - value of XML encoding attribute in declaration; a value of null represents no encoding attribute
           (string, optional, default: "UTF-8")
     * `attributeString` - the name of the property representing an element's attributes; note that any property with a
-      name equal to the attribute string is ignored except in the context of XML attributes (string, optional, default: 
+      name equal to the attribute string is ignored except in the context of XML attributes (string, optional, default:
       "@")
     * `valueString` - the name of the property representing an element's value; note that any property with a name equal
       to the value string is ignored except in the context of supplying a value for a tag containing attributes (string,
@@ -49,8 +49,8 @@ The js2xmlparser module contains one function which takes the following argument
     * `prettyPrinting` - pretty-printing options (object, optional)
         * `enabled` - specifies whether pretty-printing is enabled (boolean, optional, default: true)
         * `indentString` - indent string (string, optional, default: "\t")
-    * `convertMap` - maps object types (as given by the `Object.prototype.toString.call` method) to functions to convert 
-      those objects to a particular string representation; `*` can be used as a wildcard for all types of objects 
+    * `convertMap` - maps object types (as given by the `Object.prototype.toString.call` method) to functions to convert
+      those objects to a particular string representation; `*` can be used as a wildcard for all types of objects
       (object, optional, default: {})
     * `useCDATA` - specifies whether strings should be enclosed in CDATA tags; otherwise, illegal XML characters will
       be escaped (boolean, optional, default: false)

--- a/lib/js2xmlparser.js
+++ b/lib/js2xmlparser.js
@@ -184,7 +184,7 @@
                         for (var attribute in object[property][attributeString]) {
                             if (object[property][attributeString].hasOwnProperty(attribute)) {
                                 xml += " " + attribute + "=\"" +
-                                    toString(object[property][attributeString][attribute]) + "\"";
+                                    toString(object[property][attributeString][attribute], true) + "\"";
                             }
                         }
                     }
@@ -265,7 +265,10 @@
     };
 
     // Convert anything into a valid XML string representation
-    var toString = function(data) {
+    var toString = function(data, isAttribute) {
+
+        isAttribute = isAttribute === true ? true : false;
+
         // Recursive function used to handle nested functions
         var functionHelper = function(data) {
             if (Object.prototype.toString.call(data) === "[object Function]") {
@@ -297,7 +300,9 @@
             data = (data === null || typeof data === "undefined") ? "" : data.toString();
         }
 
-        if (useCDATA) {
+        // If we should output data as CDATA elements and this string is not
+        // being used in an attribute
+        if (useCDATA && !isAttribute) {
             data = "<![CDATA[" + data.replace(/]]>/gm, "]]]]><![CDATA[>") + "]]>";
         }
         else {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "Parses JavaScript objects into XML",
     "keywords":    ["convert","converter","js","json","object","objects","parse","parser","xml"],
     "homepage":    "http://www.kourlas.net",
-    "version":     "0.1.4",
+    "version":     "0.1.5",
     "author":      "Michael Kourlas <michael@kourlas.net>",
     "main":        "./lib/js2xmlparser.js",
     "repository" : {


### PR DESCRIPTION
This PR will fix an issue when `useCDATA` is true, CDATA values will be used in attribute values, which is not valid.

This simply disables using CDATA for XML attributes.
