### PR TITLE
Add .gitattributes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .idea/
 node_modules
 
+# already tracked, but should be added to generated .npmignore
+.gitattributes
+
 #################
 ## Eclipse
 #################


### PR DESCRIPTION
The file is already being tracked, so this won't affect git operation,
but adding .gitattributes here has the effect of it being added to the
.npmignore file that npm pack/publish generate. This is desirable
because otherwise any dependant project that chooses to commit their
node_modules directroy to git is inheriting the developer's environment
specific setting in this file.

To turn the fun up to 11, the line endings in the published version of
this project match the host environment of the publisher and are not
convered to the the preferred normalized form configured in the
.gitattributes file. So anyone installing and committing on Linux will
get a nice screen of errors for all the CRLF files (including the
.gitattributes file itself, which was a useful clue) being added to
git.

/cc @sam-github
