### PR TITLE
Add arrayMap functionality to provide wrapped array elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The js2xmlparser module contains one function which takes the following argument
 
 * `root` - the XML root element's name (string, mandatory)
 * `data` - the data to be converted to XML; while the data object can contain arrays, it cannot itself be an array
+  unless the root element is listed in the arrayMap option
   (object or JSON string, mandatory)
 * `options` - module options (object, optional)
     * `declaration` - XML declaration options (object, optional)
@@ -53,6 +54,9 @@ The js2xmlparser module contains one function which takes the following argument
         * `indentString` - indent string (string, optional, default: "\t")
     * `convertMap` - maps object types (as given by the `Object.prototype.toString.call` method) to functions to convert
       those objects to a particular string representation; `*` can be used as a wildcard for all types of objects
+      (object, optional, default: {})
+    * `arrayMap` - maps the names of arrays to the names of array elements. If an array name is listed in the map,
+      the element name will be used to wrap the array and each element will be named based on the mapped name
       (object, optional, default: {})
     * `useCDATA` - specifies whether strings should be enclosed in CDATA tags; otherwise, illegal XML characters will
       be escaped (boolean, optional, default: false)
@@ -166,7 +170,7 @@ This example uses the alias string feature:
     >     <telephone>456-555-7890</telephone>
     > </person>
 
-The following an example that uses the convert map feature:
+The following is an example that uses the convert map feature:
 
     var js2xmlparser = require("js2xmlparser");
 
@@ -196,6 +200,37 @@ The following an example that uses the convert map feature:
     >             return &quot;john@smith.com&quot;;
     >         }</email>
     > 	  <dateOfBirth>1964-08-26T05:00:00.000Z</dateOfBirth>
+    > </person>
+
+This is an example that uses the array map feature:
+
+    var js2xmlparser = require("js2xmlparser");
+
+    var data = {
+        "name": "jonathan",
+        "nicknames": [
+            "jon", "jonny", "jonno"
+        ],
+        "awards": [ "best teacher" ]
+    }
+
+    var options = {
+        arrayMap: {
+            nicknames: "name"
+        }
+    };
+
+    console.log(js2xmlparser("person", data, options));
+
+    > <?xml version="1.0" encoding="UTF-8"?>
+    > <person>
+    >     <name>jonathan</name>
+    >     <nicknames>
+    >         <name>jon</name>
+    >         <name>jonny</name>
+    >         <name>jonno</name>
+    >     </nicknames>
+    >     <awards>best teacher</awards>
     > </person>
 
 Here's an example that wraps strings in CDATA tags instead of escaping invalid characters:

--- a/example/example.js
+++ b/example/example.js
@@ -127,6 +127,26 @@
     console.log("=========");
 
     var example5 = {
+        "name": "jonathan",
+        "nicknames": [
+            "jon", "jonny", "jonno"
+        ],
+        "awards": [ "best teacher" ]
+    }
+
+    var example5Options = {
+        arrayMap: {
+            nicknames: "name"
+        }
+    };
+
+    console.log(js2xmlparser("person", example5, example5Options));
+    console.log();
+
+    console.log("EXAMPLE 6");
+    console.log("=========");
+
+    var example6 = {
         "comment": {
             "@": {
                 "type": "status"
@@ -135,9 +155,9 @@
         }
     };
 
-    var example5Options = {
+    var example6Options = {
         useCDATA: true
     };
 
-    console.log(js2xmlparser("person", example5, example5Options));
+    console.log(js2xmlparser("person", example6, example6Options));
 })();

--- a/lib/js2xmlparser.js
+++ b/lib/js2xmlparser.js
@@ -30,6 +30,7 @@
     var prettyPrinting = true;
     var indentString = "\t";
     var convertMap = {};
+    var arrayMap = {};
     var useCDATA = false;
 
     module.exports = function (root, data, options) {
@@ -121,6 +122,14 @@
                     throw new Error("convertMap option must be an object");
                 }
             }
+            if ("arrayMap" in options) {
+                if (Object.prototype.toString.call(options.arrayMap) === "[object Object]") {
+                    arrayMap = options.arrayMap;
+                }
+                else {
+                    throw new Error("arrayMap option must be an object");
+                }
+            }
             if ("useCDATA" in options) {
                 if (typeof options.useCDATA === "boolean") {
                     useCDATA = options.useCDATA;
@@ -141,8 +150,8 @@
             throw new Error("data must be an object (excluding arrays) or a JSON string");
         }
 
-        if (Object.prototype.toString.call(data) === "[object Array]") {
-            throw new Error("data must be an object (excluding arrays) or a JSON string");
+        if (Object.prototype.toString.call(data) === "[object Array]" && !(arrayMap && arrayMap[root])) {
+            throw new Error("data must be an object (excluding arrays) or a JSON string, unless an arrayMap option exists for root");
         }
 
         if (typeof data === "string") {
@@ -185,12 +194,26 @@
 
                 // Arrays
                 if (Object.prototype.toString.call(object[property]) === "[object Array]") {
+                    if (arrayMap[property]) {
+                        xml += addIndent("<" + elementName, level);
+                        xml += addBreak(">");
+                    }
                     // Create separate XML elements for each array element
                     for (i = 0; i < object[property].length; i++) {
                         tempObject = {};
-                        tempObject[property] = object[property][i];
+                        var newLevel = level;
 
-                        xml = toXML(tempObject, xml, level);
+                        if (arrayMap[property]) {
+                            tempObject[arrayMap[property]] = object[property][i]; 
+                            newLevel = level + 1;
+                        } else {
+                            tempObject[property] = object[property][i];
+                        }
+
+                        xml = toXML(tempObject, xml, newLevel);
+                    }
+                    if (arrayMap[property]) {
+                        xml += addBreak(addIndent("</" + elementName + ">", level));
                     }
                 }
                 // JSON-type objects with properties
@@ -341,6 +364,7 @@
     var setOptionDefaults = function () {
         useCDATA = false;
         convertMap = {};
+        arrayMap = {};
         xmlDeclaration = true;
         xmlVersion = "1.0";
         xmlEncoding = "UTF-8";

--- a/test/test.js
+++ b/test/test.js
@@ -941,7 +941,7 @@
                             declaration: {
                                 include: false
                             },
-                            convertMap: "test"
+                            arrayMap: "test"
                         });
                     } catch (e) {
                         e.should.match(/arrayMap option must be an object/);

--- a/test/test.js
+++ b/test/test.js
@@ -858,6 +858,116 @@
                 });
             });
 
+            describe("arrayMap", function () {
+                it("should raise an error when options is defined and options.arrayMap is undefined", function () {
+                    var res;
+                    try {
+                        res = js2xmlparser(defaultRoot, defaultData, {
+                            declaration: {
+                                include: false
+                            },
+                            arrayMap: undefined
+                        });
+                    } catch (e) {
+                        e.should.match(/arrayMap option must be an object/);
+                    }
+                    should.not.exist(res);
+                });
+
+                it("should raise an error when options is defined and options.arrayMap is null", function () {
+                    var res;
+                    try {
+                        res = js2xmlparser(defaultRoot, defaultData, {
+                            declaration: {
+                                include: false
+                            },
+                            arrayMap: null
+                        });
+                    } catch (e) {
+                        e.should.match(/arrayMap option must be an object/);
+                    }
+                    should.not.exist(res);
+                });
+
+                it("should raise an error when options is defined and options.arrayMap is an array", function () {
+                    var res;
+                    try {
+                        res = js2xmlparser(defaultRoot, defaultData, {
+                            declaration: {
+                                include: false
+                            },
+                            arrayMap: []
+                        });
+                    } catch (e) {
+                        e.should.match(/arrayMap option must be an object/);
+                    }
+                    should.not.exist(res);
+                });
+
+                it("should raise an error when options is defined and options.arrayMap is a boolean", function () {
+                    var res;
+                    try {
+                        res = js2xmlparser(defaultRoot, defaultData, {
+                            declaration: {
+                                include: false
+                            },
+                            arrayMap: true
+                        });
+                    } catch (e) {
+                        e.should.match(/arrayMap option must be an object/);
+                    }
+                    should.not.exist(res);
+                });
+
+                it("should raise an error when options is defined and options.arrayMap is a number", function () {
+                    var res;
+                    try {
+                        res = js2xmlparser(defaultRoot, defaultData, {
+                            declaration: {
+                                include: false
+                            },
+                            arrayMap: 6
+                        });
+                    } catch (e) {
+                        e.should.match(/arrayMap option must be an object/);
+                    }
+                    should.not.exist(res);
+                });
+
+                it("should raise an error when options is defined and options.arrayMap is a string", function () {
+                    var res;
+                    try {
+                        res = js2xmlparser(defaultRoot, defaultData, {
+                            declaration: {
+                                include: false
+                            },
+                            convertMap: "test"
+                        });
+                    } catch (e) {
+                        e.should.match(/arrayMap option must be an object/);
+                    }
+                    should.not.exist(res);
+                });
+
+                it("should correctly parse XML using arrayMap maps", function () {
+                    var res = js2xmlparser(defaultRoot, {
+                        "a": [ "d" ],
+                        "c": [ "e", "f" ]
+                    }, {
+                        declaration: {
+                            include: false
+                        },
+                        prettyPrinting: {
+                            enabled: false
+                        },
+                        arrayMap: {
+                            "c": "x"
+                        }
+                    });
+                    res.should.equal("<base><a>d</a><c><x>e</x><x>f</x></c></base>");
+                });
+            });
+
             describe("useCDATA", function () {
                 it("should raise an error when options is defined and options.useCDATA is undefined", function () {
                     var res;
@@ -1097,7 +1207,7 @@
                 try {
                     res = js2xmlparser(defaultRoot, [], defaultOptions);
                 } catch (e) {
-                    e.should.match(/data must be an object (excluding arrays) or a JSON string/);
+                    e.should.match(/data must be an object (excluding arrays) or a JSON string, unless an arrayMap option exists for root/);
                 }
                 should.not.exist(res);
             });
@@ -1107,9 +1217,24 @@
                 try {
                     res = js2xmlparser(defaultRoot, "test", defaultOptions);
                 } catch (e) {
-                    e.should.match(/data must be an object (excluding arrays) or a JSON string/);
+                    e.should.match(/data must be an object (excluding arrays) or a JSON string, unless an arrayMap option exists for root/);
                 }
                 should.not.exist(res);
+            });
+
+            it("should not raise an error when data is an array, and the root is in the arrayMap", function () {
+                var res = js2xmlparser(defaultRoot, [ "a" ], {
+                    declaration: {
+                        include: false
+                    },
+                    prettyPrinting: {
+                        enabled: false
+                    },
+                    arrayMap: {
+                        base: 'x'
+                    }
+                });
+                res.should.equal("<base><x>a</x></base>");
             });
 
             it("should correctly parse a number", function () {


### PR DESCRIPTION
Hey,

I've added some optional functionality to allow for wrapped array elements, rather than them appearing inline. This was done by adding a new option `arrayMap`. I've also updated the readme and examples to reflect the change. Finally, I've also added relevant tests to the test suite.

I notice that others have suggested this kind of change before. However, in this case it is sufficiently general and lightweight that it just requires the user to add the option to start using it and it can be used for each named array independently.

Let me know what you think.

Cheers!