### PR TITLE
Allow attributes in the root element of the XML tree.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 3.0.1 ## 
+
+* Add ability to add attributes to the root XML node.
+
 ## 3.0.0 ##
 
 * Bug fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2xmlparser",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Parses JavaScript objects into XML",
   "keywords": [
     "convert",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,11 @@
     "gulp-typescript": "^3.1.5",
     "merge2": "^1.0.3",
     "mocha": "^3.2.0",
-    "tslint": "^4.4.2",
+    "tslint": "4.4.2",
     "typedoc": "^0.5.7",
     "typescript": "^2.1.6"
+  },
+  "scripts": {
+    "preinstall": "node_modules/.bin/gulp prod"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {XmlAttribute, XmlDocument, XmlElement} from "xmlcreate";
-import {IOptions, Options} from "./options";
+import {IOptions, IRootAttributes, Options } from "./options";
 import {
     isArray,
     isMap,
@@ -262,13 +262,15 @@ function parseValue(key: string, value: any, parentElement: XmlElement,
  *             XML, it will be a child of this root element.
  * @param value The value to convert to XML.
  * @param options Options for parsing the value into XML.
+ * @param attributes Extra attributes to use in the root element.
  *
  * @returns An XML document corresponding to the specified value.
  *
  * @private
  */
 function parseToDocument(root: string, value: any,
-                         options: Options): XmlDocument
+                         options: Options,
+                         attributes?: IRootAttributes): XmlDocument
 {
     const document: XmlDocument = new XmlDocument(root);
     if (options.declaration.include) {
@@ -276,6 +278,11 @@ function parseToDocument(root: string, value: any,
     }
     if (options.dtd.include) {
         document.dtd(options.dtd.name!, options.dtd.sysId, options.dtd.pubId);
+    }
+    if (attributes) {
+        Object.keys(attributes).forEach((attribute) => {
+            document.root().attribute(attribute, attributes[attribute]).up();
+        });
     }
     parseValue(root, value, document.root() as XmlElement, options);
     return document;
@@ -289,11 +296,15 @@ function parseToDocument(root: string, value: any,
  * @param object The object to convert to XML.
  * @param options Options for parsing the object and formatting the resulting
  *                XML.
+ * @param attributes Extra attributes to use in the root element.
  *
  * @returns An XML string representation of the specified object.
  */
-export function parse(root: string, object: any, options?: IOptions): string {
+export function parse(root: string,
+                      object: any,
+                      options?: IOptions,
+                      attributes?: IRootAttributes): string {
     const opts: Options = new Options(options);
-    const document = parseToDocument(root, object, opts);
+    const document = parseToDocument(root, object, opts, attributes);
     return document.toString(opts.format);
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -612,3 +612,12 @@ export class WrapHandlers implements IWrapHandlers {
         }
     }
 }
+
+export interface IAttribute {
+    key: string;
+    value: string;
+}
+
+export interface IRootAttributes {
+    [key: string]: IAttribute;
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -613,6 +613,10 @@ export class WrapHandlers implements IWrapHandlers {
     }
 }
 
+/**
+ * Typed interface to use to provide attributes to the root
+ * element of an XML document.
+ */
 export interface IRootAttributes {
     [key: string]: string;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -613,11 +613,6 @@ export class WrapHandlers implements IWrapHandlers {
     }
 }
 
-export interface IAttribute {
-    key: string;
-    value: string;
-}
-
 export interface IRootAttributes {
-    [key: string]: IAttribute;
+    [key: string]: string;
 }

--- a/test/src/main.ts
+++ b/test/src/main.ts
@@ -1016,5 +1016,30 @@ describe("parser", () => {
                 });
             });
         });
+
+        describe("root attributes", () => {
+            it("should have an attribute when supplied", () => {
+                assert.strictEqual(
+                    parse("SomeElement",
+                        {"hello": {"#": "world"}},
+                        undefined,
+                        {"xmlns": "http://soap.com"}),
+                    "<?xml version='1.0'?>\n" +
+                    "<SomeElement xmlns='http://soap.com'>\n" +
+                    "    <hello>world</hello>\n" +
+                    "</SomeElement>");
+            });
+            it("should be able to handle multiple attributes", () => {
+                assert.strictEqual(
+                    parse("SomeElement",
+                        {"hello": {"#": "world"}},
+                        undefined,
+                        {"xmlns": "http://soap.com", "abcd": "efgh"}),
+                    "<?xml version='1.0'?>\n" +
+                    "<SomeElement xmlns='http://soap.com' abcd='efgh'>\n" +
+                    "    <hello>world</hello>\n" +
+                    "</SomeElement>");
+            });
+        });
     });
 });


### PR DESCRIPTION
When creating soap requests, it's necessary to have a document similar to something like:

```xml
<?xml version="1.0"?>
<soap:Envelope xmlns="some-namespace" xmlns:soap="some-other-namespace">
    <OtherStuff/>
</soap:Envelope>
````

Previously this library could not do that, but this PR fixes that.

```javascript
const js2xml = require('js2xmlparser');
console.log(js2xml.parse('soap:Envelope', {'Some': {'#': 'payload'}}, undefined, {'xmlns:soap': 'some-other-namespace', 'xmlns': 'some-namespace'});
```